### PR TITLE
data/org.ayatana.indicator.a11y: In Arctica Greeter the a11y indicato…

### DIFF
--- a/data/org.ayatana.indicator.a11y
+++ b/data/org.ayatana.indicator.a11y
@@ -8,3 +8,4 @@ ObjectPath=/org/ayatana/indicator/a11y/desktop
 
 [desktop_greeter]
 ObjectPath=/org/ayatana/indicator/a11y/desktop
+Position=1100


### PR DESCRIPTION
…r shall be placed on the very left, i.e. left of appindicator items (mainly nm-applet).

This is tricky now, as object indicators (libapplication.so) only have a stub <indobj>.get_position() API method (always returning -1). Arctica Greeter rewrites this to 1000. So, in order to end up left of the appindicators, we need to set the a11y's indicator position to a value higher than 1000.