### PR TITLE
Remove obsolete pkla file

### DIFF
--- a/data/50-org.ayatana.indicator.a11y.AccountsService.pkla
+++ b/data/50-org.ayatana.indicator.a11y.AccountsService.pkla
@@ -1,6 +1,0 @@
-[Allow LightDM to set AccountsService fields]
-Identity=unix-user:lightdm
-Action=org.ayatana.indicator.a11y.AccountsService.ModifyAnyUser
-ResultActive=yes
-ResultInactive=yes
-ResultAny=yes

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -31,10 +31,6 @@ install (CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../../
 
 install (FILES org.ayatana.indicator.a11y.AccountsService.policy DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/polkit-1/actions")
 
-# 50-org.ayatana.indicator.a11y.AccountsService.pkla
-
-install (FILES 50-org.ayatana.indicator.a11y.AccountsService.pkla DESTINATION "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/lib/polkit-1/localauthority/10-vendor.d")
-
 # 50-org.ayatana.indicator.a11y.AccountsService.rules
 
 install (FILES 50-org.ayatana.indicator.a11y.AccountsService.rules DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/polkit-1/rules.d")


### PR DESCRIPTION
This has been superseded by the JavaScript based .rules and .policy files that are already provided

Debian and Ubuntu were the last distros to use .pkla files but Debian 13 and Ubuntu 26.04 LTS don't support .pkla files

https://bugs.debian.org/1093059